### PR TITLE
feat: release workflow

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -5,6 +5,12 @@ on:
       - "*"
   workflow_dispatch:
   workflow_call:
+    inputs:
+      environment:
+        description: 'Environment to build for'
+        required: true
+        type: string
+        default: 'development'
 
 env:
   REGISTRY: docker.io
@@ -72,6 +78,8 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: mode=max
           sbom: true
+          build-args: |
+            NODE_ENV=${{ inputs.environment || 'production' }}
 
       - name: Extract buildx-generated SBOM
         id: sbom-extract

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -4,6 +4,7 @@ on:
     tags:
       - "*"
   workflow_dispatch:
+  workflow_call:
 
 env:
   REGISTRY: docker.io

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -31,23 +31,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: '.node-version'
-          cache: 'npm'
-          cache-dependency-path: zmuda-pro/package-lock.json
-
-      - name: Install dependencies
-        working-directory: zmuda-pro
-        run: npm ci
-
-      - name: Build Docusaurus site
-        working-directory: zmuda-pro
-        run: npm run build
-        env:
-          NODE_ENV: production
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -73,6 +73,11 @@ jobs:
 
   docker-build-test:
     name: Docker Build Test
+    permissions:
+      contents: read
+      artifact-metadata: write
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/build-and-push.yaml
     with:
       environment: 'development'

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -81,6 +81,7 @@ jobs:
     uses: ./.github/workflows/build-and-push.yaml
     with:
       environment: 'development'
+    secrets: inherit
 
   summary:
     name: All Checks Passed

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -73,7 +73,7 @@ jobs:
 
   docker-build-test:
     name: Docker Build Test
-    uses: ./.github/workflows/docker-build-test.yaml
+    uses: ./.github/workflows/build-and-push.yaml
     with:
       environment: 'development'
 

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -41,7 +41,7 @@ jobs:
         working-directory: zmuda-pro
         run: npm run build
         env:
-          NODE_ENV: production
+          NODE_ENV: development
 
       - name: Check build output
         run: |
@@ -50,13 +50,6 @@ jobs:
             exit 1
           fi
           echo "✅ Build successful - output directory exists"
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: build-output
-          path: zmuda-pro/build
-          retention-days: 1
 
   pre-commit:
     name: Pre-commit Checks
@@ -80,32 +73,9 @@ jobs:
 
   docker-build-test:
     name: Docker Build Test
-    runs-on: ubuntu-latest
-    needs: build-and-test
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: build-output
-          path: zmuda-pro/build
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Build Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          platforms: "linux/amd64"
-          push: false
-          tags: zmuda-pro-blog:pr-${{ github.event.pull_request.number }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    uses: ./.github/workflows/docker-build-test.yaml
+    with:
+      environment: 'development'
 
   summary:
     name: All Checks Passed

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: main
-          fetch-depth: 0   # need full tag history to compute next version
+          fetch-depth: 0
 
       - name: Compute next calendar version
         id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,57 @@
+name: Cut Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: main
+          fetch-depth: 0   # need full tag history to compute next version
+
+      - name: Compute next calendar version
+        id: version
+        run: |
+          YEAR=$(date +'%Y')
+          MONTH=$(date +'%-m')   # no leading zero
+          PREFIX="${YEAR}.${MONTH}."
+
+          # Find existing tags matching this year.month.*, extract the highest xx
+          LATEST=$(git tag -l "${PREFIX}*" | sed "s/^${PREFIX}//" | sort -n | tail -1)
+
+          if [ -z "$LATEST" ]; then
+            NEXT=1
+          else
+            NEXT=$((LATEST + 1))
+          fi
+
+          VERSION="${YEAR}.${MONTH}.${NEXT}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Computed version: $VERSION"
+
+      - name: Set up git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump package.json version
+        working-directory: zmuda-pro
+        run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+
+      - name: Commit version bump
+        run: |
+          git add zmuda-pro/package.json zmuda-pro/package-lock.json
+          git commit -m "chore(release): ${{ steps.version.outputs.version }}"
+          git push origin main
+
+      - name: Create and push tag
+        run: |
+          git tag ${{ steps.version.outputs.version }}
+          git push origin ${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 # syntax=docker/dockerfile:1
 FROM dhi.io/node:26-alpine3.23-dev AS builder
 
-ENV NODE_ENV=production
+ARG NODE_ENV=development
+ENV NODE_ENV=${NODE_ENV}
 
+# Copy the entire git repo to the container to allow showLastUpdateTime on blog pages
 COPY . /blog
 WORKDIR /blog/zmuda-pro
 RUN npm ci --omit=dev && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,13 @@
-FROM dhi.io/nginx:1.31.2-alpine3.23
+# syntax=docker/dockerfile:1
+FROM dhi.io/node:26-alpine3.23-dev AS builder
 
-COPY zmuda-pro/build /usr/share/nginx/html
+ENV NODE_ENV=production
+
+COPY . /blog
+WORKDIR /blog/zmuda-pro
+RUN npm ci --omit=dev && npm run build
+
+FROM dhi.io/nginx:1.31.2-alpine3.23 AS runtime
+
+COPY --from=builder /blog/zmuda-pro/build /usr/share/nginx/html
 COPY default.conf /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for automating the release process. The workflow calculates a calendar-based version, bumps the `package.json` version in the `zmuda-pro` directory, commits and pushes the changes, and creates a corresponding git tag.

**Release automation:**

* Added a new workflow `.github/workflows/release.yaml` that automates version calculation (using a year.month.increment format), updates the `zmuda-pro/package.json` version, commits and pushes the change to `main`, and creates a matching git tag.