### PR TITLE
feat: Optional push, no push on pr

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -11,6 +11,11 @@ on:
         required: true
         type: string
         default: 'development'
+      push:
+        description: 'Whether to push the image to the registry'
+        required: true
+        type: boolean
+        default: true
 
 env:
   REGISTRY: docker.io
@@ -53,7 +58,7 @@ jobs:
         with:
           context: .
           platforms: "linux/amd64"
-          push: true
+          push: ${{ inputs.push }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
@@ -65,6 +70,7 @@ jobs:
             NODE_ENV=${{ inputs.environment || 'production' }}
 
       - name: Extract buildx-generated SBOM
+        if: ${{ inputs.push }}
         id: sbom-extract
         run: |
           docker buildx imagetools inspect \
@@ -73,6 +79,7 @@ jobs:
 
       - name: Attest SBOM
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        if: ${{ inputs.push }}
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-push.outputs.digest }}
@@ -81,6 +88,7 @@ jobs:
 
       - name: Attest Provenance
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        if: ${{ inputs.push }}
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-push.outputs.digest }}

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -81,6 +81,7 @@ jobs:
     uses: ./.github/workflows/build-and-push.yaml
     with:
       environment: 'development'
+      push: false
     secrets: inherit
 
   summary:


### PR DESCRIPTION
This pull request introduces a configurable option to control whether Docker images are pushed to the registry in the `build-and-push.yaml` workflow. It also updates the `pr-checks.yaml` workflow to disable pushing images during pull request checks. The main goal is to make image pushing optional, improving workflow flexibility and preventing unnecessary pushes in CI checks.

**Workflow input and behavior changes:**

* Added a new boolean input `push` to `build-and-push.yaml`, defaulting to `true`, to control whether the Docker image is pushed to the registry.
* Updated the Docker build step to use the value of `inputs.push` for the `push` parameter, instead of always pushing.
* Conditionalized SBOM extraction, SBOM attestation, and provenance attestation steps to only run if `push` is `true`, ensuring these steps are skipped when not pushing. [[1]](diffhunk://#diff-0d2cab11c4e5a0cd4482d237752463d77bc7002aeacef14affe501b2d75dddbbR73) [[2]](diffhunk://#diff-0d2cab11c4e5a0cd4482d237752463d77bc7002aeacef14affe501b2d75dddbbR82) [[3]](diffhunk://#diff-0d2cab11c4e5a0cd4482d237752463d77bc7002aeacef14affe501b2d75dddbbR91)

**Workflow usage update:**

* Modified `pr-checks.yaml` to set `push: false` when invoking `build-and-push.yaml`, preventing image pushes during PR checks.