### PR TITLE
fix: 404 on /aboutme

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -6,7 +6,7 @@ server {
         root   /usr/share/nginx/html;
         index  index.html;
         add_header Cache-Control "public, max-age=86400";
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ $uri.html =404;
     }
 
     error_page  404              /404.html;

--- a/default.conf
+++ b/default.conf
@@ -4,8 +4,9 @@ server {
 
     location / {
         root   /usr/share/nginx/html;
-        index  index.html index.htm;
+        index  index.html;
         add_header Cache-Control "public, max-age=86400";
+        try_files $uri $uri/ /index.html;
     }
 
     error_page  404              /404.html;


### PR DESCRIPTION
This pull request makes a small update to the Nginx configuration for serving static files. The change simplifies the `index` directive and adds a `try_files` directive to improve client-side routing support, which is commonly used in single-page applications.

- Nginx configuration improvements:
  * In the `location /` block of `default.conf`, removed `index.htm` from the `index` directive so that only `index.html` is used.
  * Added a `try_files $uri $uri/ $uri.html =404;` directive to ensure that requests for non-existent files return 404