### PR TITLE
ci: pin the shared workflow to v2.0.0-rc

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a75831dcde77fb4ad7caa180497a48fd0be072c4 # v1.0.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@94086bb6b9c07ff6c9a073e0ac79c24415ec18ed # v1.1.0
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can


### PR DESCRIPTION
Follow-up to #110, which moved these callers onto
[`theadzik/github-workflows`](https://github.com/theadzik/github-workflows). This repins
them from v1.0.0 to **v2.0.0-rc**.

## What v2 changes

v1 pushed the image by digest and then scanned what it had pushed. v2 builds into an OCI
layout on disk, scans it there, and only pushes if the scan passes:

```text
build → OCI layout → Trivy → push by digest (no tag)
      → cosign sign → attest SBOM → attest provenance → cosign verify → publish tags
```

That ordering matters more here than in homelab. This image is an npm build, so a rebuild
is not reproducible — under the old two-build shape, a cache miss meant Trivy had cleared
an artifact that was not the one being signed.

Pushing a layout without writing a tag needs `regctl`; `imagetools create` refuses to run
without `--tag` and skopeo rejects a digest destination. Verified against a scratch
registry — same digest, attestation manifest intact, no tags written.

v1.1.0 (never merged here) also added `cosign sign` plus a `cosign verify` gate before
tags publish, since `actions/attest` only signs statements *about* the image while the
homelab `ImageValidatingPolicy` opens with `verifyImageSignatures(...) > 0`. Included here.

Inputs are unchanged, so this is a pin change only.

## Testing

Nothing in this PR runs a build: `website-checks` excludes workflow files from its path
filter, so Dependabot action bumps do not trigger a Lighthouse audit — and that exclusion
now also means the pinned rc is never exercised by PR CI.

After merge:

```bash
gh workflow run manual-build.yaml -f environment=production -f push=false -f tags=''
```

builds and scans without publishing. A `push: true` run against a throwaway tag is what
would exercise the push, signature and attestation steps for the first time anywhere —
happy to drive that and check the resulting referrers.

Open items are tracked in
[workflows-issues.md](https://github.com/theadzik/github-workflows/blob/main/workflows-issues.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)