### PR TITLE
ci: pin the shared workflow to v2.0.0-rc.2 (fix cosign rate limit)

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@454a41dd5740cf83df3dc54f2ff5281591f9f100 # v2.0.0-rc
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can


### PR DESCRIPTION
Fixes what [run 30610770330](https://github.com/theadzik/blog/actions/runs/30610770330)
hit — the `2026.7.31-alpha` build, and the first time the v2 push path ran anywhere.

## What happened

```text
Error: signing [docker.io/theadzik/zmuda-pro-blog@sha256:456ea2ff…]: accessing image:
GET https://index.docker.io/v2/theadzik/zmuda-pro-blog/manifests/sha256:456ea2ff…:
TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit.
```

cosign reads the image manifest before signing it, and it did not use the `docker login`
credentials in `~/.docker/config.json` — the same file `regctl` and the docker CLI used
successfully earlier in that job. It pulled anonymously and hit Docker Hub's limit.

rc.2 passes `--registry-username` and `--registry-password` explicitly to both `cosign
sign` and `cosign verify`. That sidesteps the discrepancy rather than explaining it; why
cosign's keychain misses a config other tools read is still open.

## What that run did prove

- `regctl image copy` pushed the layout **by digest against Docker Hub**, and the digest
  check passed — previously only shown against a scratch registry.
- The `regctl-installer` ran `cosign verify-blob` on its own binary, so the
  cosign-before-regctl ordering did what it was ordered for.
- **The gate behaved correctly under failure.** The job died before `Publish tags`, and
  Docker Hub has no `2026.7.31-alpha` tag — an orphan digest, nothing deployable. That is
  precisely why the push happens by digest with no tag.

## Testing this

Push another alpha tag once merged. That exercises `cosign sign`, `cosign verify`, both
attestations and `Publish tags` — everything still unproven — and the referrers on the
resulting digest also settle whether Kyverno will accept the Sigstore bundle cosign 3.x
writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)