### PR TITLE
ci: pin the shared workflow to v2.0.0-rc.3 (mint cosign's registry token)

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1da8cf0325767a1bae37c18cc3cdb0ba9c9a6f48 # v2.0.0-rc.2
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can


### PR DESCRIPTION
rc.2 failed the same way rc did — [run 30611680353](https://github.com/theadzik/blog/actions/runs/30611680353),
`2026.7.31-rc2`, dead at `Sign image` on Docker Hub's unauthenticated pull rate limit —
even though credentials were passed to cosign explicitly.

## Why passing credentials wasn't enough

Every mechanism I could test checks out, which is what made this stubborn:

| Hypothesis | Test | Result |
| --- | --- | --- |
| `secrets: inherit` doesn't reach a workflow in another repo | login step output, step env | `Login Succeeded!`, `REGISTRY_PASSWORD: ***` — secret arrives |
| cosign ignores the flags | auth-required local registry, creds only via flags | 404 with, `UNAUTHORIZED` without — flags work |
| Broken in pinned v3.0.6 | same test on v3.0.6 and v3.1.2 | both authenticate |
| Only Basic auth works, not Docker Hub's bearer flow | same test against ghcr.io | `DENIED` without, 404 with — bearer works |
| Docker Hub 429s before issuing a challenge | unauthenticated GET | `401` + `WWW-Authenticate: Bearer` |
| Flags never reach the failing call | read `sign.go` @ v3.0.6 | `regOpts.ClientOpts(ctx)` *is* passed to the call that raises `accessing image` |

The account wasn't over its limit either — `regctl manifest head`, an authenticated read,
succeeded seconds earlier in the same job.

**What makes it silent:** for a public repository, Docker Hub's token endpoint returns
HTTP 200 with an *anonymous* token even when credentials are missing or rejected. cosign
sees a valid token and no error; the failure only appears later as a rate limit on a
request that was never authenticated.

## The fix

Both cosign steps now mint the bearer token themselves:

```bash
token=$(curl -fsSL -u "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" \
  "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO_PATH}:pull,push" \
  | jq -er .token)
cosign sign --yes --registry-token "${token}" "${IMAGE_REF}@${DIGEST}"
```

cosign then sends `Authorization: Bearer` directly and negotiates nothing. Validated
against a bearer-flow registry: minted token → authenticated, no token → `DENIED`. Bad
credentials now fail loudly on the `curl -f` instead of silently becoming an anonymous
pull.

`--registry-password` is basic auth — correct for a Docker Hub PAT, but it leaves the
token exchange to cosign. `--registry-token` is the bearer token that exchange would have
produced.

## Testing

Push another alpha tag after merge. `cosign sign`, `cosign verify`, both attestations and
`Publish tags` are all still unproven — the previous two runs never got past signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)