### PR TITLE
ci: pin the shared workflow to v2.0.0-rc.4 (diagnose the cosign auth failure)

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@3c1f0e3742030eb33e2a28991936f0f4827b7d52 # v2.0.0-rc.3
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can


### PR DESCRIPTION
rc.3 failed the same way — [run 30648166490](https://github.com/theadzik/blog/actions/runs/30648166490),
`Sign image`, Docker Hub's unauthenticated pull rate limit — even though the step minted a
bearer token and passed it as `--registry-token`.

## Why I'm instrumenting instead of guessing again

Three mechanisms have now failed identically on the runner: the ambient `docker login`,
`--registry-username`/`--registry-password`, and `--registry-token`. All three
authenticate correctly from a workstation, against a basic-auth registry **and** a
bearer-flow one (ghcr.io), on cosign v3.0.6 and v3.1.2, in the keyless path as well as the
keyed one. `sign.go` at v3.0.6 passes `regOpts.ClientOpts(ctx)` into the exact call that
raises `accessing image`.

The logs cannot separate the two remaining explanations:

1. The token minted on the runner is anonymous. Docker Hub answers a pull-scope request
   for a **public** repository with HTTP 200 and an anonymous token when credentials are
   rejected — so `curl -f` succeeding proves nothing on its own. (Confirmed: no
   credentials → 200 + `sub: ""`, `pull_limit: 100`. Wrong or empty credentials → 401,
   which `curl -f` does catch.)
2. cosign is discarding the token it is given.

## What rc.4 adds

Before signing, the step now:

- decodes the token's claims and **fails loudly if `sub` is empty**, i.e. if Docker Hub
  handed back an anonymous token despite the credentials;
- performs an authenticated `GET` of the same manifest with that token and prints the
  status and `ratelimit-*` headers.

If that read succeeds and cosign still reports an unauthenticated pull, the problem is
inside cosign, not the credentials and not the account's limit — and the next step is to
stop using the cosign CLI for this. Note `actions/attest` already writes to Docker Hub
successfully from these runners (your published images carry its referrers), so the runner
itself can authenticate for registry writes.

If the token turns out to be anonymous, the problem is the credential and the fix is on
the Docker Hub side.

Also picks up Dependabot's action bumps that landed on the shared repo's `main`
(`login-action` v4.6.0, `trivy-action`, `attest` v4.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)