### PR TITLE
ci: pin the shared workflow to v2.0.0-rc.5 (measure cosign's registry auth)

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe25fd27c84d8dbbb35fde52118a75510d7 # v2.0.0-rc.4
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can


### PR DESCRIPTION
Signing worked in [run 30649345089](https://github.com/theadzik/blog/actions/runs/30649345089)
— the full chain ran for the first time. But nothing we changed explains it:

```text
16:41:55Z  failure   (rc.3)
16:59:05Z  success   (rc.4)
```

The `cosign sign` invocation is **byte-identical** between those two rcs; rc.4 only added
diagnostics ahead of it. Same binary, same credentials, seventeen minutes apart.

The credentials were not the problem in the run that passed — the minted token was
demonstrably authenticated:

```text
HTTP/2 200
docker-ratelimit-source: theadzik      # the account, not an IP
x-ratelimit-limit: 200;w=3600
x-ratelimit-remaining: 150;w=3600
```

The most economical explanation left is that cosign reads the manifest **anonymously in
every run**, and Docker Hub's anonymous limit is per-IP (100/6h, shared by everything on
that runner address). Three runs landed on an exhausted address; one didn't. If that's
right, this is a lottery rather than a fix.

## What rc.5 does

**Removes every way cosign could end up anonymous.** Credentials now reach it three ways at
once: an isolated `DOCKER_CONFIG` for its keychain, the minted bearer token via
`--registry-token`, and the username/password that token was minted from.

**Measures which one it used.** Each rate-limit reading is itself one authenticated pull,
so bracketing the signature with two readings leaves cosign's own spend:

- `before - after - 1 == 0` → cosign authenticated with none of the three; the job survived
  on the shared IP's anonymous quota. Reported as a `::warning`.
- `>= 1` → cosign used the credentials and the flow is genuinely authenticated.

Either way the next tag build answers it in its own log, instead of us inferring from
whether it happened to pass.

## Already settled by the last run

The digest carries three referrers — SBOM, provenance, and the signature as
`https://sigstore.dev/cosign/sign/v1` (an OCI referrer, not the `sha256-*.sig` tag 2.x
wrote). Its certificate SAN is
`https://github.com/theadzik/github-workflows/.github/workflows/build-and-push.yaml@68e8afe…`,
which your Kyverno `subjectRegExp` matches. The only open question there is whether Kyverno
reads referrer-style bundles — testable against `theadzik/zmuda-pro-blog:tellme`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)