### PR TITLE
ci: pin the shared workflow to v2.0.0-rc.6 (make the measurement survive failure)

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a3b2efca2c1ba25ed42198fceda6b286aaf2b2e5 # v2.0.0-rc.6
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a3b2efca2c1ba25ed42198fceda6b286aaf2b2e5 # v2.0.0-rc.6
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/tag-release-build.yaml
+++ b/.github/workflows/tag-release-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a3b2efca2c1ba25ed42198fceda6b286aaf2b2e5 # v2.0.0-rc.6
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -26,7 +26,7 @@ jobs:
       artifact-metadata: write
       attestations: write
       id-token: write
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@385f40d549c2e2d3320ad1454bebe9314c9691e9 # v2.0.0-rc.5
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@a3b2efca2c1ba25ed42198fceda6b286aaf2b2e5 # v2.0.0-rc.6
     with:
       image-name: zmuda-pro-blog
       # Full history is required: the Dockerfile copies .git so Docusaurus can


### PR DESCRIPTION
The rc.5 measurement was useless in exactly the case it was built for.
[Run 30650855873](https://github.com/theadzik/blog/actions/runs/30650855873) failed at
`Sign image` on cosign **v3.1.2** — so the version is not the variable either — and printed
nothing, because `before` was captured without being echoed and `set -e` aborted the step
before the second reading.

rc.6 prints both readings as they are taken and defers cosign's exit code until after the
second one, then exits with it. A failing signature now still tells us whether cosign's
reads counted against the account.

## Two outcomes, both useful

- **`before` is near zero** → the account is out of its 200/hour budget, and Docker Hub's
  "unauthenticated" wording is misleading. That would also explain the constant 429s
  Kyverno reports in the cluster, and the fix is on the quota side, not in this workflow.
- **`before` is healthy and `used == 0`** → cosign genuinely does not use the credentials
  it is handed, and a passing run is passing on the runner IP's anonymous quota.

## Correction carried into the workflow comment

I described rc.5 as supplying credentials three ways at once. That was wrong.
`GetRegistryClientOpts` takes the **first** of keychain, k8s keychain,
username+password, registry token — so `--registry-token` shadows the `DOCKER_CONFIG`
written for the keychain, which never gets consulted. Dropping the flag is what would
exercise that config, and that combination is still untried. The comment above the step now
says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)