### PR TITLE
ci: add a dispatchable probe for the cosign auth failure

### DIFF
--- a/.github/workflows/cosign-auth-probe.yaml
+++ b/.github/workflows/cosign-auth-probe.yaml
@@ -1,0 +1,116 @@
+name: Cosign Auth Probe
+
+# Temporary diagnostic for the signing failures in theadzik/github-workflows.
+# Delete once issue 7 in that repo's workflows-issues.md is closed.
+#
+# Runs no build. It probes an image that is already published, using
+# `cosign tree` - a read-only command that goes through the same
+# ociremote.SignedEntity call that fails during `cosign sign` - once per
+# credential mechanism, taking the account's pull quota either side of each
+# attempt. One run says which mechanism authenticates, or that none does
+# because the account itself is out of budget.
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: "Published image to probe (tag or digest)."
+        required: true
+        type: string
+        default: "docker.io/theadzik/zmuda-pro-blog:tellme"
+
+permissions: {}
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Populates ~/.docker/config.json exactly as the real workflow does, so
+      # the first probe measures the ambient keychain rather than a synthetic one.
+      - name: Login to registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: docker.io
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v3.1.2
+
+      - name: Probe every credential mechanism
+        env:
+          IMAGE: ${{ inputs.image }}
+          REGISTRY_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |-
+          set -euo pipefail
+
+          ref_part="${IMAGE#docker.io/}"
+          if [[ "${ref_part}" == *@* ]]; then
+            REPO_PATH="${ref_part%@*}"; REF="${ref_part#*@}"
+          else
+            REPO_PATH="${ref_part%:*}"; REF="${ref_part##*:}"
+          fi
+          echo "Probing ${REPO_PATH} at ${REF}"
+
+          mint() {
+            curl -fsSL -u "${REGISTRY_USERNAME}:${REGISTRY_PASSWORD}" \
+              "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${REPO_PATH}:pull" \
+              | jq -er .token
+          }
+
+          # One authenticated pull per call, which is what makes it a meter.
+          quota() {
+            local t
+            t=$(mint) || return 1
+            curl -s -o /dev/null -D- \
+              -H "Authorization: Bearer ${t}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json" \
+              "https://index.docker.io/v2/${REPO_PATH}/manifests/${REF}" \
+              | tr -d '\r' | sed -nE 's/^ratelimit-remaining: ([0-9]+).*/\1/Ip' | head -1
+          }
+
+          # An empty config dir for the flag-based probes, so a stray keychain
+          # hit cannot be mistaken for the flag working.
+          mkdir -p "${RUNNER_TEMP}/empty"
+          echo '{}' > "${RUNNER_TEMP}/empty/config.json"
+
+          mkdir -p "${RUNNER_TEMP}/written"
+          auth=$(printf '%s:%s' "${REGISTRY_USERNAME}" "${REGISTRY_PASSWORD}" | base64 -w0)
+          jq -n --arg a "${auth}" \
+            '{auths: {"https://index.docker.io/v1/": {auth: $a}}}' > "${RUNNER_TEMP}/written/config.json"
+
+          token=$(mint)
+
+          probe() {
+            local label="$1" cfg="$2"; shift 2
+            local before after used rc
+            before=$(quota || true)
+            set +e
+            DOCKER_CONFIG="${cfg}" cosign tree "$@" "${IMAGE}" > "${RUNNER_TEMP}/${label}.log" 2>&1
+            rc=$?
+            set -e
+            after=$(quota || true)
+            used="?"
+            if [[ -n "${before}" && -n "${after}" ]]; then
+              used=$(( before - after - 1 ))
+            fi
+            printf '%-16s exit=%-3s quota %5s -> %-5s cosign spent %s\n' \
+              "${label}" "${rc}" "${before:-?}" "${after:-?}" "${used}"
+            grep -oiE "TOOMANYREQUESTS|UNAUTHORIZED|DENIED|MANIFEST_UNKNOWN|not found" \
+              "${RUNNER_TEMP}/${label}.log" | head -1 | sed 's/^/                 saw: /' || true
+          }
+
+          echo
+          echo "mechanism        result   account pull quota"
+          echo "--------------------------------------------------------------"
+          probe ambient-login   "${HOME}/.docker"
+          probe written-config  "${RUNNER_TEMP}/written"
+          probe user-password   "${RUNNER_TEMP}/empty" --registry-username "${REGISTRY_USERNAME}" --registry-password "${REGISTRY_PASSWORD}"
+          probe registry-token  "${RUNNER_TEMP}/empty" --registry-token "${token}"
+          echo "--------------------------------------------------------------"
+          echo "spent >= 1 means cosign used that mechanism; 0 means it read anonymously."
+          echo "A quota near zero everywhere means the account is out of budget and"
+          echo "Docker Hub's 'unauthenticated' wording is misleading."


### PR DESCRIPTION
Testing one credential mechanism per tag build is slow, and each attempt costs a full image
build. This probes **all four in a single dispatch, and builds nothing** — it reads an
image that is already published.

## How it works

`cosign tree` is the vehicle: read-only, goes through the same `ociremote.SignedEntity`
call that raises `accessing image` during `cosign sign`, and takes the same registry
flags. Verified against a bearer-flow registry before writing this:

```text
cosign tree ghcr.io/…            → DENIED      (anonymous)
cosign tree --registry-token …   → not found   (authenticated)
```

Each mechanism is isolated so one cannot mask another:

| Probe | `DOCKER_CONFIG` | Flags |
| --- | --- | --- |
| `ambient-login` | `~/.docker` (written by `docker/login-action`) | none |
| `written-config` | a config this step writes | none |
| `user-password` | empty | `--registry-username` / `--registry-password` |
| `registry-token` | empty | `--registry-token` |

The account's pull quota is read either side of every attempt. Each reading is itself one
authenticated pull, so `before - after - 1` is what cosign spent:

```text
mechanism        result   account pull quota
--------------------------------------------------------------
ambient-login    exit=0   quota   150 -> 148   cosign spent 1
registry-token   exit=1   quota    12 -> 11    cosign spent 0
```

- **spent >= 1** → cosign used that mechanism.
- **spent 0** → it read anonymously, whatever we handed it.
- **quota near zero everywhere** → the account is out of its 200/hour budget and Docker
  Hub's "unauthenticated" wording is misleading, which would also explain the constant 429s
  Kyverno reports in the cluster.

## To run it

Merge, then dispatch — default target is `docker.io/theadzik/zmuda-pro-blog:tellme`, the
digest signed successfully at 16:59, so it already carries referrers for `cosign tree` to
list. It needs `permissions: {}` and no build, so it costs about a minute.

Delete the file once issue 7 is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)