### PR TITLE
ci: fail loudly when PR image cleanup cannot list versions

### DIFF
--- a/.github/workflows/pr-image-cleanup.yaml
+++ b/.github/workflows/pr-image-cleanup.yaml
@@ -31,13 +31,27 @@ jobs:
         run: |-
           set -euo pipefail
 
-          versions=$(gh api --paginate "/users/${OWNER}/packages/container/${PACKAGE}/versions" 2>/dev/null || echo '[]')
+          # gh prints the error body to stdout and exits non-zero, so failures
+          # must be caught here rather than fed to jq: iterating an error object
+          # yields its values, and the run reports "nothing to delete" for what
+          # is really a permission or availability problem.
+          if ! versions=$(gh api --paginate "/users/${OWNER}/packages/container/${PACKAGE}/versions" 2>"${RUNNER_TEMP}/gh-error"); then
+            if grep -q '(HTTP 404)' "${RUNNER_TEMP}/gh-error"; then
+              # Nothing was ever published under this name - the normal outcome
+              # for a PR that touched no website paths.
+              echo "No ${PACKAGE} package in ghcr.io; nothing to delete"
+              exit 0
+            fi
+            cat "${RUNNER_TEMP}/gh-error" >&2
+            echo "::error title=PR image::Could not list versions of ${PACKAGE}"
+            exit 1
+          fi
 
           version=$(jq -c --arg tag "${TAG}" \
             '[.[] | select(.metadata.container.tags // [] | index($tag))] | first // empty' <<< "${versions}")
 
           if [[ -z "${version}" ]]; then
-            # The PR touched no website paths, so no image was ever built.
+            # The package exists, but nothing carries this PR's tag.
             echo "No ${PACKAGE}:${TAG} to delete"
             exit 0
           fi


### PR DESCRIPTION
Addresses the review on `pr-image-cleanup.yaml:35`. The reviewer was right, and it had
already happened — [run 30688404080](https://github.com/theadzik/blog/actions/runs/30688404080)
reported success while doing nothing:

```text
jq: error (at <stdin>:1): Cannot index string with string "metadata"
No zmuda-pro-blog:pr-118 to delete
```

## What actually went wrong

`gh api` writes the error body to **stdout** and exits non-zero. So on failure:

```bash
versions=$(gh api ... 2>/dev/null || echo '[]')
# versions = {"message":"Package not found.",...}[]
```

jq then iterated the error object's *values* — strings — hence `Cannot index string with
string`. The step swallowed that too and printed "nothing to delete". Reproduced locally
against a package that does not exist:

```text
exit=1
stdout: {"message":"Package not found.","documentation_url":"..."}
stderr: gh: Package not found. (HTTP 404)
```

In this run the outcome happened to be correct — nothing has been published to GHCR yet —
but a revoked token, a package whose Actions access changed, or a transient 5xx would have
produced exactly the same "clean" result.

## The fix

404 is still benign, everything else fails:

```bash
if ! versions=$(gh api --paginate "..." 2>"${RUNNER_TEMP}/gh-error"); then
  if grep -q '(HTTP 404)' "${RUNNER_TEMP}/gh-error"; then
    echo "No ${PACKAGE} package in ghcr.io; nothing to delete"
    exit 0
  fi
  cat "${RUNNER_TEMP}/gh-error" >&2
  echo "::error title=PR image::Could not list versions of ${PACKAGE}"
  exit 1
fi
```

The error body never reaches jq now, since the failure branch exits first.

Tested against all three paths:

| Case | Result |
| --- | --- |
| package missing (404) | exit 0, "nothing to delete" |
| permission denied (403) | **exit 1**, gh's message printed |
| package exists, tag present | proceeds to delete |

The two "nothing to delete" outcomes are also no longer conflated: a missing *package* and
a missing *tag* now print different messages, so the log says which one it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)