### PR TITLE
ci: pin the shared workflow to v2.2.0 (CycloneDX SBOM)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   build-and-push:
     name: Build and push image
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@59202524db1536b7e91d4c8a9e16e9de15f1ab24 # v2.2.0
     permissions:
       contents: read
       artifact-metadata: write

--- a/.github/workflows/manual-build.yaml
+++ b/.github/workflows/manual-build.yaml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-and-push:
-    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@1d7be13ba716c8f074a22d26eb8cfa7b032d00e8 # v2.1.0
+    uses: theadzik/github-workflows/.github/workflows/build-and-push.yaml@59202524db1536b7e91d4c8a9e16e9de15f1ab24 # v2.2.0
     permissions:
       contents: read
       artifact-metadata: write


### PR DESCRIPTION
Picks up [github-workflows#2](https://github.com/theadzik/github-workflows/pull/2), which generates the SBOM with syft as CycloneDX instead of BuildKit as SPDX.

## Why

Trivy could not read the SPDX SBOMs we publish, and said so by reporting **zero** OS packages rather than an error. Root cause is that syft's SPDX writer emits no `OPERATING-SYSTEM` package and Trivy's parser needs one to establish distro context. syft's CycloneDX writer declares the OS, and both Trivy and Grype read it.

## Validated on this repo before release

`manual-build` was dispatched against the release candidate and the published attestation checked directly:

| Check | Result |
| --- | --- |
| Predicate type | `https://cyclonedx.org/bom` |
| `cosign verify-attestation` vs the policy's signer identity | passes |
| Components / OS | 73, alpine 3.23 |
| `trivy sbom` OS packages | **12** (was 0) |
| `grype` | alpine-3.23, 0 matches |

## Sequencing

Blog images built after this merge carry a CycloneDX attestation. **homelab's Kyverno policy still matches `https://spdx.dev/Document/v2.3`**, so it will report an SBOM verification failure for those images until its matching PR lands. The policy is in `Audit` with `failurePolicy: Ignore`, so this degrades PolicyReports rather than blocking admission — but the two should land close together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)